### PR TITLE
Upgrade to SNAFU 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,18 +427,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["encoding"]
 
 [dependencies]
 log = "0.4"
-snafu = "0.8"
+snafu = "0.9"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 /// The public Error type for this library.
 #[derive(Debug, Snafu)]
+#[snafu(source(from(exact)))]
 pub struct Error(LibError);
 
 /// The public Result type for this library.


### PR DESCRIPTION
Thanks for using SNAFU! I've just released version 0.9 and my tests caught that your crate would be affected by some of the SemVer-incompatible changes in this version. See the [CHANGELOG][] for a full list.

This commit tries to make the minimal amount of changes to get your code compiling again, but it's entirely possible that there are better solutions for your specific case.

This version also updates the minimum supported Rust version to Rust 1.65 and targets Rust 1.81 by default. I didn't check how these changes affect might your crate, so please make sure to use your judgment as well!

Please feel free to take this PR in whatever form is useful to you; I'm not interested in becoming a long-term contributor to your project, so I'd prefer to not learn your project-specific rules or sign anything like a CLA. I don't mind someone with project approval yoinking these changes and committing it themselves and side-stepping all the red tape.

[CHANGELOG]: https://github.com/shepmaster/snafu/blob/main/CHANGELOG.md#090---2026-03-02
